### PR TITLE
Adds alerts for task-loading errors, with a 'group' mechanism.

### DIFF
--- a/src/FocusedProofreading.jsx
+++ b/src/FocusedProofreading.jsx
@@ -289,6 +289,7 @@ function FocusedProofreading(props) {
   }, [actions, dvidMngr]);
 
   const setupTask = React.useCallback(() => {
+    const onError = (group) => (error) => { actions.addAlert({ group, message: error }); };
     setTaskStartTime(Date.now());
     const json = assnMngr.taskJson();
     const bodyPts = bodyPoints(json);
@@ -296,12 +297,12 @@ function FocusedProofreading(props) {
       return new Promise((resolve) => { resolve(false); });
     }
     return (
-      dvidMngr.getBodyId(bodyPts[0])
+      dvidMngr.getBodyId(bodyPts[0], onError(1))
         .then((bodyId0) => (
-          dvidMngr.getBodyId(bodyPts[1]).then((bodyId1) => [bodyId0, bodyId1])
+          dvidMngr.getBodyId(bodyPts[1], onError(2)).then((bodyId1) => [bodyId0, bodyId1])
         ))
         .then(([bodyId0, bodyId1]) => (
-          dvidMngr.getKeyValue('segmentation_focused', dvidLogKey(bodyId0, bodyId1))
+          dvidMngr.getKeyValue('segmentation_focused', dvidLogKey(bodyId0, bodyId1), onError(3))
             .then((data) => [bodyId0, bodyId1, data])
         ))
         .then(([bodyId0, bodyId1, prevResult]) => {

--- a/src/WorkSpaces.jsx
+++ b/src/WorkSpaces.jsx
@@ -8,6 +8,7 @@ import { connect } from 'react-redux';
 // if possible.
 import NeuroGlancer from '@janelia-flyem/react-neuroglancer';
 
+import { addAlert } from './actions/alerts';
 import {
   initViewer, setViewerGrayscaleSource, setViewerSegmentationSource,
   setViewerCameraPosition, setViewerCameraProjectionScale, setViewerCameraProjectionOrientation,
@@ -102,6 +103,9 @@ const WorkSpacesActions = (dispatch) => ({
     },
     setViewerCameraProjectionOrientation: (newState) => {
       dispatch(setViewerCameraProjectionOrientation(newState));
+    },
+    addAlert: (newState) => {
+      dispatch(addAlert(newState));
     },
   },
 });

--- a/src/actions/alerts.js
+++ b/src/actions/alerts.js
@@ -1,11 +1,15 @@
 import C from '../reducers/constants';
 
-export function addAlert({ message, duration, severity }) {
+// If `group` is specified, then any other alerts with that group will be replaced by this one.
+export function addAlert({
+  message, duration, severity, group,
+}) {
   return {
     type: C.ALERT_ADD,
     message,
     duration,
     severity,
+    group,
   };
 }
 

--- a/src/reducers/alerts.js
+++ b/src/reducers/alerts.js
@@ -6,10 +6,12 @@ const alertState = Immutable.List([]);
 export default function userReducer(state = alertState, action) {
   switch (action.type) {
     case C.ALERT_ADD: {
-      return state.push({
+      const s = (action.group) ? state.filterNot((x) => x.group === action.group) : state;
+      return s.push({
         message: action.message,
         severity: action.severity,
         duration: action.duration,
+        group: action.group,
       });
     }
     case C.ALERT_DELETE: {


### PR DESCRIPTION
When the alert mechanism was added, the intention was that "only the most recent alert is displayed, automatically closing the previous alert."  But in practice, if an alert is shown for each error when loading a task, and every task in a list fails to load, then there are dozens of alerts that the user must close.  To avoid this situation, `addAlert` now takes an optional `group` argument.  Adding an alert with a particular `group` value closes all other open alerts with the same `group` value. So, for example, when loading a list of tasks that can fail in a couple different ways, the user will end up seeing one alert for each of the different ways the loading failed.