### PR TITLE
Adds a simple help dialog, with key bindings.

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,2 @@
 HTTPS=true
+REACT_APP_VERSION=$npm_package_version

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neurohub",
-  "version": "0.1.0",
+  "version": "0.9.0",
   "private": true,
   "dependencies": {
     "@babel/core": "7.4.3",

--- a/src/FocusedProofreadingHelp.jsx
+++ b/src/FocusedProofreadingHelp.jsx
@@ -1,0 +1,47 @@
+import Button from '@material-ui/core/Button';
+import Dialog from '@material-ui/core/Dialog';
+import DialogActions from '@material-ui/core/DialogActions';
+import DialogContent from '@material-ui/core/DialogContent';
+import DialogTitle from '@material-ui/core/DialogTitle';
+import PropTypes from 'prop-types';
+import Table from '@material-ui/core/Table';
+import TableBody from '@material-ui/core/TableBody';
+import TableCell from '@material-ui/core/TableCell';
+import TableRow from '@material-ui/core/TableRow';
+import Typography from '@material-ui/core/Typography';
+import React from 'react';
+
+export default function FocusedProofreadingHelp(props) {
+  const { keyBindings, open, onClose } = props;
+
+  return (
+    <Dialog onClose={onClose} open={open} disableEnforceFocus>
+      <DialogTitle>Focused Proofreading Help</DialogTitle>
+      <DialogContent>
+        <Typography color="inherit">{`Version ${process.env.REACT_APP_VERSION}`}</Typography>
+        <Typography color="inherit">Key bindings:</Typography>
+        <Table>
+          <TableBody>
+            {Object.entries(keyBindings).map((e) => (
+              <TableRow key={e[1].key}>
+                <TableCell align="right">{e[1].key}</TableCell>
+                <TableCell align="left">{e[1].help}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </DialogContent>
+      <DialogActions>
+        <Button autoFocus onClick={onClose} color="primary">
+          OK
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}
+
+FocusedProofreadingHelp.propTypes = {
+  keyBindings: PropTypes.object.isRequired,
+  open: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+};


### PR DESCRIPTION
Ultimately, we probably want this help page to be triggered by the `i` icon on the navbar.  But that approach will take some refactoring that is too big a project for now (e.g., the revised behavior of the `i` button probably needs to involve the Redux state, but that state is defined at a level below the `<Navbar>` component).  Another problem is that when the user clicks "HIDE HEADER" to make more room for the proofreading graphics, the `i` icon is hidden.  So for now, I am adding a cheap-and-cheerful solution, a `?` button with the controls of the focused proofreading protocol itself.  We can retire this solution when we rework the `i` icon.