### PR TITLE
Prevents "menu shake" on windows, buy fixing layer title.

### DIFF
--- a/src/Neuroglancer.css
+++ b/src/Neuroglancer.css
@@ -7,3 +7,16 @@
 .neuroglancer-container {
   height: 100%;
 }
+
+.neuroglancer-layer-side-panel-title {
+  display: block !important;
+}
+
+.neuroglancer-layer-side-panel-title input {
+  max-width: 135px;
+  overflow:hidden;
+}
+
+.neuroglancer-layer-side-panel-title .neuroglancer-icon {
+  float:right;
+}


### PR DESCRIPTION
The sidebar panel title was too wide for the sidebar when reduced to the
smallest size. This css change makes sure the title can't be too large
for the smallest side panel width and prevents the scrollbar from
showing, causing the "shake".